### PR TITLE
feat: Add actions support

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,6 +3,7 @@ module.exports = {
   addons: [
     '@storybook/addon-actions',
     '@storybook/addon-links',
-    '@storybook/addon-knobs/register'
+    '@storybook/addon-knobs/register',
+    '@storybook/addon-actions/register',
   ]
 }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ This library only works if Stories don't leave behind some global state. It is r
 
 Knobs are also supported. It is possible to create a story where all properties are knob imports and change those inputs during a test.
 
+Actions are supported as well. All emitted actions are collected and can be investigated using the `cy.loggedActions` command.
+
 An example Cypress file might look like this:
 
 ```js

--- a/cypress.d.ts
+++ b/cypress.d.ts
@@ -25,5 +25,14 @@ declare namespace Cypress {
      * @param value Value of the knob. The type is not checked, so make sure it is valid for your story
      */
     changeKnob(name: string, value: any): Cypress.Chainable<null>
+
+    /**
+     * Retrieve all actions that have been logged for a given action type.
+     * Returns an array of arguments for each invocation of the action.
+     * @param type The action type as passed into the `action` function. E.g. `click` for `action('click')('foo')`.
+     * @example
+     * cy.loggedActions('click').should('not.be.empty')
+     */
+    loggedActions(type: string): Cypress.Chainable<any[][]>
   }
 }

--- a/cypress.js
+++ b/cypress.js
@@ -54,3 +54,10 @@ Cypress.Commands.add('changeKnob', (name, value) => {
 
   return null
 })
+
+Cypress.Commands.add('loggedActions', (type) => {
+  const win = cy.state('window')
+  return win.___actions
+    .filter(action => action.data.name === type)
+    .map(action => action.data.args);
+});

--- a/cypress/integration/button.spec.js
+++ b/cypress/integration/button.spec.js
@@ -44,6 +44,15 @@ describe('Button', () => {
         cy.get('#clicked').should('contain', 'clicked!')
       })
 
+      it('should collect an action for the button click', () => {
+        cy.loggedActions('click').should('not.be.empty');
+        cy.loggedActions('click').should('have.length', 1);
+        cy.loggedActions('click').should(args => {
+          expect(args[0]).to.contain('foo');
+          expect(args[0]).to.contain('bar');
+        });
+      })
+
       context('when the Button/Text story is re-rendered', () => {
         beforeEach(() => {
           cy.loadStory('Button', 'Text')
@@ -51,6 +60,7 @@ describe('Button', () => {
 
         it('should reset all state', () => {
           cy.get('button').should('not.contain', 'clicked')
+          cy.loggedActions('click').should('be.empty');
         })
       })
     })

--- a/react.js
+++ b/react.js
@@ -3,6 +3,7 @@ import addons from '@storybook/addons'
 import Events from '@storybook/core-events'
 import { toId } from '@storybook/router'
 import ReactDOM from 'react-dom'
+import { EVENT_ID } from '@storybook/addon-actions'
 
 function setCurrentStory(categorization, story) {
   clearCurrentStory()
@@ -17,6 +18,9 @@ function setCurrentStory(categorization, story) {
 function clearCurrentStory() {
   var root = document.querySelector('#root')
   ReactDOM.unmountComponentAtNode(root)
+
+  // Also reset logged actions.
+  window.___actions = [];
 }
 
 function changeKnob(changedKnob) {
@@ -28,3 +32,10 @@ function changeKnob(changedKnob) {
 
 window.__setCurrentStory = setCurrentStory
 window.__changeKnob = changeKnob
+
+// Collect actions emitted by storybook/addon-actions
+window.___actions = [];
+
+addons.getChannel().addListener(EVENT_ID, args => {
+  window.___actions.push(args);
+});

--- a/stories/1-Button.stories.js
+++ b/stories/1-Button.stories.js
@@ -16,6 +16,7 @@ export const Text = () => {
     <React.Fragment>
       <Button
         onClick={() => {
+          action('click')('foo', 'bar')
           setClicked(true)
         }}
       >


### PR DESCRIPTION
Added support for `@storybook/addon-actions` that allows asserting actions being triggered.

```jsx
<Button onClick={() => action('click')('foo')}>Test</Button>
```
```js
cy.loggedActions('click').should('have.length', 1);
```