### PR TITLE
fix: Story names are converted to kebab-case

### DIFF
--- a/cypress.js
+++ b/cypress.js
@@ -16,7 +16,7 @@ Cypress.Commands.add('loadStory', (categorization, story) => {
   const now = performance.now()
   win.__setCurrentStory(
     categorization.replace(/[|/]/g, '-').toLowerCase(),
-    story.replace(/\s/g, '-').toLowerCase()
+    story.replace(/\s/g, '-').replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase()
   )
   log.set('consoleProps', () => ({
     categorization,

--- a/cypress/integration/camelcase.spec.js
+++ b/cypress/integration/camelcase.spec.js
@@ -1,0 +1,10 @@
+describe('loadStory', () => {
+  before(() => {
+    cy.visitStorybook()
+  })
+
+  it('can load camel cased story names', () => {
+    cy.loadStory('CamelCase/CamelCase', 'CamelCase');
+    cy.contains('This is a CamelCased story');
+  });
+});

--- a/stories/3-CamelCase.stories.js
+++ b/stories/3-CamelCase.stories.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default {
+  title: 'CamelCase/CamelCase',
+}
+
+export const CamelCase = () => <p>This is a CamelCased story</p>


### PR DESCRIPTION
CamelCased story names are transformed into kebab-case when storybook turns them into URLs. This is *not* the case for folders, which seem to be just lowercased. Thats why `loadStory` doesn't work with camel case stories (as shown in the test added with this PR).