### PR TITLE
Enable IE11 compatibility out of the box

### DIFF
--- a/common.js
+++ b/common.js
@@ -68,7 +68,10 @@ export function changeArg(updatedArgs) {
   console.log(updatedArgs)
   addons
     .getChannel()
-    .emit(Events.UPDATE_STORY_ARGS, { storyId: window.__storyId, updatedArgs })
+    .emit(Events.UPDATE_STORY_ARGS, {
+      storyId: window.__storyId,
+      updatedArgs: updatedArgs,
+    })
 }
 
 addons


### PR DESCRIPTION
IE11 is not compatible with object-shorthand-properties.
As this is only used once in the package, it feels valuable
enough to favor the long version. This will make the package
directly IE11-compatible.