### PR TITLE
changeArgs Reset

### DIFF
--- a/common.js
+++ b/common.js
@@ -50,6 +50,10 @@ function resetKnobs() {
   addons.getChannel().emit('storybookjs/knobs/reset')
 }
 
+function resetArgs(storyId) {
+  addons.getChannel().emit(Events.RESET_STORY_ARGS, { storyId, storyId })
+}
+
 export function setCurrentStory(categorization, story) {
   resetKnobs()
   resetActions()
@@ -57,6 +61,7 @@ export function setCurrentStory(categorization, story) {
   addons.getChannel().emit(Events.SET_CURRENT_STORY, {
     storyId: window.__storyId,
   })
+  resetArgs(window.__storyId)
   addons.getChannel().emit('storybookjs/knobs/reset')
 }
 
@@ -66,12 +71,10 @@ export function changeKnob(changedKnob) {
 
 export function changeArg(updatedArgs) {
   console.log(updatedArgs)
-  addons
-    .getChannel()
-    .emit(Events.UPDATE_STORY_ARGS, {
-      storyId: window.__storyId,
-      updatedArgs: updatedArgs,
-    })
+  addons.getChannel().emit(Events.UPDATE_STORY_ARGS, {
+    storyId: window.__storyId,
+    updatedArgs: updatedArgs,
+  })
 }
 
 addons

--- a/cypress/integration/angular.spec.js
+++ b/cypress/integration/angular.spec.js
@@ -81,12 +81,13 @@ describe('Button', () => {
     })
 
     context('when the control is changed to "Test"', () => {
-      beforeEach(() => {
-        cy.changeArg('label', 'Test')
+      it('should update the text element to "Test"', () => {
+        cy.changeArg('children', 'Test')
+        cy.get('button').should('contain', 'Test')
       })
 
-      it('should update the text element to "Test"', () => {
-        cy.get('button').should('contain', 'Test')
+      it('should appropriately reset args between story loads', () => {
+        cy.get('button').should('contain', 'Button')
       })
     })
 

--- a/cypress/integration/react.spec.js
+++ b/cypress/integration/react.spec.js
@@ -102,12 +102,13 @@ describe('Button', () => {
     })
 
     context('when the control is changed to "Test"', () => {
-      beforeEach(() => {
+      it('should update the text element to "Test"', () => {
         cy.changeArg('children', 'Test')
+        cy.get('button').should('contain', 'Test')
       })
 
-      it('should update the text element to "Test"', () => {
-        cy.get('button').should('contain', 'Test')
+      it('should appropriately reset args between story loads', () => {
+        cy.get('button').should('contain', 'Button')
       })
     })
 


### PR DESCRIPTION
### Motivation

calling `.loadStory` doesn't currently reset the args that were passed to the story in subsequent loads.

### Changes

- Added `resetArgs` function for targeting a story to reset args on. Function is called on each invocation of `.loadStory`

### Testing

- start up storybook for react or angular
- `npm test`

