### PR TITLE
Fix outdated ID for react root element

### DIFF
--- a/react.js
+++ b/react.js
@@ -5,7 +5,7 @@ import { addons } from '@storybook/preview-api'
 import { FORCE_RE_RENDER } from '@storybook/core-events'
 
 function clearCurrentStory() {
-  var root = document.querySelector('#root')
+  var root = document.querySelector('#storybook-root')
   ReactDOM.unmountComponentAtNode(root)
 }
 


### PR DESCRIPTION
The #65 PR did not fix all issues for me on v7. I could not use `__setCurrentStory` because the call to `clearCurrentStory` failed with 
`Error: unmountComponentAtNode(...): Target container is not a DOM element.`

It looks like the id of the react root ID has changed to not conflict with user components' IDs. 

This fixes the outdated element ID in this package. 